### PR TITLE
Drop the eventsub table as we can use the twitch API to easily lookup…

### DIFF
--- a/routes/eventsub.js
+++ b/routes/eventsub.js
@@ -92,11 +92,21 @@ module.exports = function(lib) {
                 // then punt the reset for background processing
                 res.status(200).send('Ok');
 
-                console.log('Got a notification', req.body.subscription.type, 'send', 'twitch_discord:' + req.body.subscription.type);
+                var { subscription } = req.body;
+                var { id, cost, type } = subscription;
+
+                console.log('Got a notification', cost, type, 'send', 'twitch_discord:' + type);
+
+                //if (cost == 1 && type != 'user.authorization.revoke') {
+                //    // cost 1 and not auth revoke
+                //    // destroy
+                //    eventsub.unsubscribe(id);
+                //    return;
+                //}
 
                 // fire and forget
                 redis_client.PUBLISH(
-                    'twitch_discord:' + req.body.subscription.type,
+                    'twitch_discord:' + type,
                     JSON.stringify(req.body)
                 );
 

--- a/sql/barrys_discord_twitch.sql
+++ b/sql/barrys_discord_twitch.sql
@@ -19,16 +19,6 @@ CREATE TABLE `channels` (
   UNIQUE KEY `channels_twitch_user_id_idx` (`twitch_user_id`) USING BTREE
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
-CREATE TABLE `eventsub` (
-  `ref_id` bigint unsigned NOT NULL AUTO_INCREMENT,
-  `twitch_user_id` varchar(25) COLLATE utf8mb4_general_ci DEFAULT NULL,
-  `topic` varchar(50) COLLATE utf8mb4_general_ci DEFAULT NULL,
-  `eventsub_id` varchar(50) COLLATE utf8mb4_general_ci DEFAULT NULL,
-  UNIQUE KEY `ref_id` (`ref_id`),
-  UNIQUE KEY `eventsub_twitch_user_id_topic_idx` (`twitch_user_id`,`topic`) USING BTREE,
-  KEY `eventsub_twitch_user_id_idx` (`twitch_user_id`) USING BTREE
-) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
-
 CREATE TABLE `links` (
   `ref_id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `twitch_user_id` varchar(25) COLLATE utf8mb4_general_ci DEFAULT NULL,

--- a/utils/runner.js
+++ b/utils/runner.js
@@ -77,33 +77,16 @@ subscriber
             }
         );
     });
-    // @Todo: if cost 1 kill subs for user
+    // @Todo: if cost 1 kill subs for user?
 
 
-function processUserDie(user_id) {
+async function processUserDie(user_id) {
     console.log('Terminating', user_id);
+    // delete all data
 
-    // find stored EventSub ID's to termiante
-    mysql_pool.query(
-        'SELECT eventsub_id FROM eventsub WHERE twitch_user_id = ?',
-        [
-            user_id
-        ],
-        (e,r) => {
-            if (e) {
-                console.log(e);
-                return;
-            }
-            if (r.length == 0) {
-                console.log('Nothing to revoke');
-                return;
-            }
-            for (var x=0;x<r.length;x++) {
-                console.log('Terminate', user_id, r[x].eventsub_id);
-                eventsub.unsubscribe(r[x].eventsub_id);
-            }
-        }
-    );
+    // unsubscribe
+    let subscriptions = await eventsub.getSubscriptions(r[x].eventsub_id);
+    eventsub.userUnsubscribe(subscriptions);
 
     // force set the channel to Not Live
     mysql_pool.query(


### PR DESCRIPTION
… subs for a user regardless of topic

By submitting this pull request, I confirm that my contribution is made under the terms of the WTFPL license.

## Problem/Feature

The `eventsub` cache table/list of topics is entirely superlous now

## Description of Changes: 

- Remove the calls to usage of the `eventsub` table as we can call the API instead
- Remove `eventsub` table from SQL create

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
- [x] I don't give a [F*ck](https://github.com/BarryCarlyon/twitch_discord_barrycarlyon_co_uk/blob/main/LICENSE) - Do What The F*ck You Want To with my Submission
